### PR TITLE
ci(dependabot): Use root for Cargo

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,6 +19,6 @@ updates:
   
   ## RUST ##
   - package-ecosystem: "cargo"
-    directory: "packages/cedar_ffi/src"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
Since the repo is a Cargo workspace, use the root for dependency updates instead of the `src` dir so that `Cargo.lock` gets updated.