### PR TITLE
chore(version): `0.1.4`

### DIFF
--- a/packages/cedar_ffi/CHANGELOG.md
+++ b/packages/cedar_ffi/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+- chore: Remove Cargo workspace
+
 ## 0.1.3
 
 - chore: Remove git submodule dependency on cedar

--- a/packages/cedar_ffi/pubspec.yaml
+++ b/packages/cedar_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cedar_ffi
 description: FFI bindings for the Cedar policy language, written in Rust.
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/celest-dev/cedar-dart/tree/main/packages/cedar_ffi
 
 environment:


### PR DESCRIPTION
Bumps `cedar_ffi` to `0.1.4`